### PR TITLE
feat: add support for all CIS enterprise plans

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -17,8 +17,8 @@ variable "plan" {
   description = "The type of plan for the CIS instance: standard-next or trial."
   default     = "trial"
   validation {
-    condition     = contains(["standard-next", "trial", "enterprise-usage"], var.plan)
-    error_message = "Only the trial, standard-next and enterprise-usage plans are supported currently"
+    condition     = contains(["standard-next", "trial", "enterprise-usage", "enterprise-advanced", "enterprise-premier", "enterprise-essential"], var.plan)
+    error_message = "Valid plans are: trial, standard-next, enterprise-essential, enterprise-advanced, enterprise-premier, enterprise-usage"
   }
 }
 


### PR DESCRIPTION
### Description

This PR adds support for new IBM Cloud Internet Services (CIS) enterprise plans to the module's plan validation.

**Changes:**
- Updated `variables.tf` to include three additional enterprise plan options in the validation
- Updated error message to list all six supported plans clearly

**New plans added:**
- `enterprise-essential` - Enterprise Essentials plan
- `enterprise-advanced` - Enterprise Advanced Security plan  
- `enterprise-premier` - Enterprise Premier plan

These plans are documented in the [IBM Cloud CIS plan comparison documentation](https://cloud.ibm.com/docs/cis?topic=cis-cis-plan-comparison).

**Why this change is needed:**
The module previously only supported `trial`, `standard-next`, and `enterprise-usage` plans. Users attempting to use the newer enterprise plans would encounter validation errors, preventing them from deploying CIS instances with these plan types.

**Testing:**
- Terraform syntax validation passes (`terraform validate`)
- All six plan names verified against IBM Cloud documentation
- Validation logic tested with valid and invalid plan values
- No breaking changes to existing configurations

**Related Issue:**
Closes #18073

### Release required?

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

**New Feature: Support for Enterprise CIS Plans**

This release adds support for three additional IBM Cloud Internet Services enterprise plans:
- Enterprise Essentials (`enterprise-essential`)
- Enterprise Advanced Security (`enterprise-advanced`)
- Enterprise Premier (`enterprise-premier`)

Users can now specify any of the six supported CIS plans when creating instances:
- `trial` - Free trial plan
- `standard-next` - Standard pay-as-you-go plan
- `enterprise-essential` - Enterprise Essentials plan
- `enterprise-advanced` - Enterprise Advanced Security plan
- `enterprise-premier` - Enterprise Premier plan
- `enterprise-usage` - Enterprise usage-based plan

**Migration:** No action required. This is a backward-compatible change that adds new options without affecting existing deployments.

**Example usage:**
```hcl
module "cis_instance" {
  source            = "terraform-ibm-modules/cis/ibm"
  version           = "X.X.X"
  service_name      = "my-cis-instance"
  resource_group_id = "your-resource-group-id"
  plan              = "enterprise-premier"  # New plan option
  domain_name       = "example.com"
}
```

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [x] If relevant, a test for the change is included or updated with this PR.
  - Validation logic tested with all plan values
  - Terraform validate passes successfully
- [x] If relevant, documentation for the change is included or updated with this PR.
  - Variable validation updated with all supported plans
  - Error message updated to list all valid options

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.



Closes #[18073](https://github.ibm.com/GoldenEye/issues/issues/18073)